### PR TITLE
Fix: Change URL to CNAME record to prevent redirect loop

### DIFF
--- a/vicknesh.json
+++ b/vicknesh.json
@@ -5,7 +5,7 @@
     "username": "vicknesh22",
     "email": "vicknesh22@gmail.com"
   },
-  "records": {
-    "URL": "https://vicknesh22.github.io/cv"
+  "record": {
+    "CNAME": "vicknesh22.github.io"
   }
 }


### PR DESCRIPTION
- Changed from URL record to CNAME record as per is-a.dev requirements
- CNAME points to vicknesh22.github.io (without /cv path)
- This prevents the redirect loop issue mentioned in PR review
- GitHub Pages will handle routing to /cv automatically via custom domain settings

Addresses reviewer feedback on PR #30844